### PR TITLE
Fix mobile keyboard focus

### DIFF
--- a/src/components/WaitlistForm.tsx
+++ b/src/components/WaitlistForm.tsx
@@ -146,7 +146,6 @@ export const WaitlistForm = component$(() => {
                 class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent"
                 placeholder="John Smith"
                 autoComplete="name"
-                autoFocus
                 required
               />
             </div>


### PR DESCRIPTION
## Summary
- remove autofocus from the name input in `WaitlistForm`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686460930ed88332b27dbada4949913f