### PR TITLE
Add ESLint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ src/
    pnpm preview
    ```
 
+5. **Run ESLint checks:**
+   ```bash
+   pnpm lint
+   ```
+
 ## 🔧 Environment Setup
 
 ### Supabase Configuration
@@ -168,6 +173,7 @@ pnpm preview
 3. Test on mobile devices
 4. Optimize for performance
 5. Update documentation
+6. Run `pnpm lint` before committing
 
 ## 📞 Support
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,27 @@
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import qwikPlugin from 'eslint-plugin-qwik';
+
+export default [
+  {
+    ignores: ['node_modules/**', 'public/**'],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      qwik: qwikPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      ...qwikPlugin.configs.recommended.rules,
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev.debug": "node --inspect-brk ./node_modules/vite/bin/vite.js --mode ssr --force",
     "fmt": "prettier --write .",
     "fmt.check": "prettier --check .",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "preview": "qwik build preview && vite preview --open",
     "start": "vite --open --mode ssr",
     "qwik": "qwik"


### PR DESCRIPTION
## Summary
- configure ESLint for TypeScript and Qwik
- add lint script to package.json
- document lint instructions in README

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6864609532cc83328f57a633bd010ec4