### PR TITLE
Fix ESLint typed linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,10 @@
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import qwikPlugin from 'eslint-plugin-qwik';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default [
   {
@@ -13,6 +17,8 @@ export default [
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
       },
     },
     plugins: {


### PR DESCRIPTION
## Summary
- use `tsconfig.json` for typed linting

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_686463759e34833282da86591c838123