### PR TITLE
Fix Qwik component handlers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,10 @@
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import qwikPlugin from 'eslint-plugin-qwik';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default [
   {
@@ -13,6 +17,8 @@ export default [
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
       },
     },
     plugins: {

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,4 +1,4 @@
-import { component$, useSignal } from '@builder.io/qwik';
+import { $, component$, useSignal } from '@builder.io/qwik';
 
 interface FAQItem {
   id: number;
@@ -52,9 +52,11 @@ export const FAQ = component$(() => {
     }
   ];
   
-  const toggleItem = (id: number) => {
-    openItem.value = openItem.value === id ? null : id;
-  };
+  const toggleItem = $(
+    (id: number) => {
+      openItem.value = openItem.value === id ? null : id;
+    }
+  );
   
   return (
     <section class="py-16 bg-white">

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -1,4 +1,4 @@
-import { component$, useSignal, useVisibleTask$ } from '@builder.io/qwik';
+import { $, component$, useSignal, useVisibleTask$ } from '@builder.io/qwik';
 
 interface Testimonial {
   id: number;
@@ -70,17 +70,23 @@ export const Testimonials = component$(() => {
     return () => clearInterval(timer);
   });
   
-  const nextTestimonial = () => {
-    current.value = (current.value + 1) % testimonials.length;
-  };
+  const nextTestimonial = $(
+    () => {
+      current.value = (current.value + 1) % testimonials.length;
+    }
+  );
   
-  const prevTestimonial = () => {
-    current.value = current.value === 0 ? testimonials.length - 1 : current.value - 1;
-  };
+  const prevTestimonial = $(
+    () => {
+      current.value = current.value === 0 ? testimonials.length - 1 : current.value - 1;
+    }
+  );
   
-  const goToTestimonial = (index: number) => {
-    current.value = index;
-  };
+  const goToTestimonial = $(
+    (index: number) => {
+      current.value = index;
+    }
+  );
   
   return (
     <section class="py-16 bg-gray-50">


### PR DESCRIPTION
## Summary
- use tsconfig.json for typed linting
- wrap FAQ and testimonial handlers in `$()` for Qwik serialization

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_686463759e34833282da86591c838123