### PR TITLE
Improve hero style and add branding assets

### DIFF
--- a/public/images/hero.svg
+++ b/public/images/hero.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="100%" stop-color="#06b6d4" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="200" rx="16" fill="url(#grad)" />
+  <g fill="#fff" font-family="Inter, sans-serif" font-size="48" font-weight="700" text-anchor="middle">
+    <text x="200" y="115">AI</text>
+  </g>
+</svg>

--- a/public/logos/logo1.svg
+++ b/public/logos/logo1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#2563eb"/>
+  <text x="60" y="38" text-anchor="middle" font-family="Inter, sans-serif" font-size="32" fill="white">A</text>
+</svg>

--- a/public/logos/logo2.svg
+++ b/public/logos/logo2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#10b981"/>
+  <text x="60" y="38" text-anchor="middle" font-family="Inter, sans-serif" font-size="32" fill="white">B</text>
+</svg>

--- a/public/logos/logo3.svg
+++ b/public/logos/logo3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#f97316"/>
+  <text x="60" y="38" text-anchor="middle" font-family="Inter, sans-serif" font-size="32" fill="white">C</text>
+</svg>

--- a/public/logos/logo4.svg
+++ b/public/logos/logo4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#6366f1"/>
+  <text x="60" y="38" text-anchor="middle" font-family="Inter, sans-serif" font-size="32" fill="white">D</text>
+</svg>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,22 +3,22 @@ import { Link } from '@builder.io/qwik-city';
 
 export const Hero = component$(() => {
   return (
-    <section class="bg-blue-600 text-white py-20">
+    <section class="bg-gradient-to-r from-blue-100 via-blue-200 to-blue-300 text-gray-900 py-20">
       <div class="max-w-6xl mx-auto px-4 text-center">
         <div class="animate-fade-in">
           <h1 class="text-5xl md:text-6xl font-bold mb-6 leading-tight">
-            Turn AI <span class="fire-glow">FOMO</span> into <span class="text-yellow-300">ROI</span>
+            Turn AI <span class="fire-glow">FOMO</span> into <span class="text-yellow-600">ROI</span>
           </h1>
           
-          <p class="text-xl md:text-2xl mb-8 text-blue-100 max-w-3xl mx-auto leading-relaxed">
-            Stop watching competitors leverage AI while you fall behind. 
-            Get live demos, expert guidance, and a custom MVP blueprint 
+          <p class="text-xl md:text-2xl mb-8 text-blue-800 max-w-3xl mx-auto leading-relaxed">
+            Stop watching competitors leverage AI while you fall behind.
+            Get live demos, expert guidance, and a custom MVP blueprint
             to transform your business with AI solutions.
           </p>
           
           <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <Link 
-              href="/demo/" 
+            <Link
+              href="/demo/"
               class="bg-white text-blue-600 px-8 py-4 rounded-2xl font-semibold text-lg hover:bg-gray-100 transition-all duration-300 hover:scale-105 shadow-lg"
             >
               🚀 Explore Live Demos
@@ -31,8 +31,9 @@ export const Hero = component$(() => {
               📋 Join Wait-list
             </Link>
           </div>
-          
-          <div class="mt-12 text-blue-200">
+          <img src="/images/hero.svg" alt="Abstract AI illustration" class="mx-auto mt-8 w-full max-w-md" />
+
+          <div class="mt-12 text-blue-700">
             <p class="text-sm mb-2">⚡ Loads in &lt;1s on mobile</p>
             <p class="text-sm">🎯 Live AI demos • 📞 Discovery calls • 💡 MVP blueprints</p>
           </div>

--- a/src/global.css
+++ b/src/global.css
@@ -4,21 +4,21 @@
 
 /* Custom fire effect styles */
 .fire-glow {
-  text-shadow:
-    0 0 32px #ffd700,
-    0 0 64px #ff6600,
-    0 0 16px #ff3300,
-    0 2px 4px #000;
-  background: linear-gradient(90deg, rgba(255,200,50,0.25) 0%, rgba(255,150,0,0.18) 50%, rgba(255,0,0,0.22) 100%);
+  text-shadow: 0 0 8px rgba(255, 115, 0, 0.6);
+  background: linear-gradient(90deg, rgba(255, 200, 50, 0.3), rgba(255, 80, 0, 0.3));
   -webkit-background-clip: text;
   background-clip: text;
-  filter: brightness(1.2) drop-shadow(0 0 40px #ffd70080) drop-shadow(0 0 80px #ff660080);
-  transition: text-shadow 0.3s, filter 0.3s;
+  filter: brightness(1.05);
+  transition: text-shadow 0.3s;
 }
 
 /* Ensure consistent box sizing without heavy global transitions */
 * {
   box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
 }
 
 /* Custom scrollbar */

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -14,6 +14,19 @@ export default component$(() => {
     <QwikCityProvider>
       <head>
         <meta charset="utf-8" />
+        <link
+          rel="preconnect"
+          href="https://fonts.googleapis.com"
+        />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
         {!isDev && (
           <link
             rel="manifest"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,30 +7,22 @@ import { Footer } from '../components/Footer';
 
 export default component$(() => {
   return (
-    <div class="min-h-screen bg-blue-600">
+    <div class="min-h-screen bg-gradient-to-b from-blue-50 via-blue-100 to-blue-200 text-gray-900">
       <NavBar />
       <Hero />
       <ValueProps />
       
-      {/* Logos row placeholder */}
+      {/* Logos */}
       <section class="py-12 bg-white">
         <div class="max-w-6xl mx-auto px-4">
           <h3 class="text-center text-gray-600 text-sm font-medium mb-8 uppercase tracking-wide">
             Trusted by leading companies
           </h3>
-          <div class="flex justify-center items-center space-x-8 opacity-60">
-            <div class="bg-gray-200 h-12 w-32 rounded flex items-center justify-center">
-              <span class="text-gray-500 text-xs">Logo 1</span>
-            </div>
-            <div class="bg-gray-200 h-12 w-32 rounded flex items-center justify-center">
-              <span class="text-gray-500 text-xs">Logo 2</span>
-            </div>
-            <div class="bg-gray-200 h-12 w-32 rounded flex items-center justify-center">
-              <span class="text-gray-500 text-xs">Logo 3</span>
-            </div>
-            <div class="bg-gray-200 h-12 w-32 rounded flex items-center justify-center">
-              <span class="text-gray-500 text-xs">Logo 4</span>
-            </div>
+          <div class="flex justify-center items-center space-x-8 opacity-80">
+            <img src="/logos/logo1.svg" alt="Alpha Corp logo" class="h-12 w-32 object-contain" />
+            <img src="/logos/logo2.svg" alt="Beta Industries logo" class="h-12 w-32 object-contain" />
+            <img src="/logos/logo3.svg" alt="Creative Solutions logo" class="h-12 w-32 object-contain" />
+            <img src="/logos/logo4.svg" alt="Delta Systems logo" class="h-12 w-32 object-contain" />
           </div>
         </div>
       </section>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,9 +5,12 @@ export default {
     extend: {
       colors: {
         primary: {
-          blue: '#0D6EFD',
-          red: '#DC3545',
-          green: '#198754'
+          blue: '#3b82f6',
+          red: '#ef4444',
+          green: '#10b981'
+        },
+        light: {
+          background: '#f0f9ff'
         }
       },
       animation: {


### PR DESCRIPTION
## Summary
- tone down fire-glow effect and use Inter font
- add Inter webfont to the document head
- apply gradient backgrounds and include hero illustration
- replace logo placeholders with simple SVG logos
- create a lighter color palette in Tailwind

## Testing
- `npm run lint` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68646acbd09483329d3f8938f1ed10c1