### PR TITLE
Refine hero styling and lighten page palette

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AISOLUTIONS - Turn AI FOMO into ROI</title>
-    <meta name="description" content="Transform your business with AI solutions. Live demos, expert consultation, and MVP blueprints." />
+    <title>AISOLUTIONS - Transform AI Potential into Business Value</title>
+    <meta name="description" content="Transform AI potential into business value with live demos, expert guidance, and MVP blueprints." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>

--- a/public/images/hero.svg
+++ b/public/images/hero.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3b82f6" />
+      <stop offset="100%" stop-color="#06b6d4" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="200" rx="16" fill="url(#grad)" />
+  <g fill="#fff" font-family="Inter, sans-serif" font-size="48" font-weight="700" text-anchor="middle">
+    <text x="200" y="115">AI</text>
+  </g>
+</svg>

--- a/public/logos/logo1.svg
+++ b/public/logos/logo1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#2563eb"/>
+  <text x="60" y="38" text-anchor="middle" font-family="Inter, sans-serif" font-size="32" fill="white">A</text>
+</svg>

--- a/public/logos/logo2.svg
+++ b/public/logos/logo2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#10b981"/>
+  <text x="60" y="38" text-anchor="middle" font-family="Inter, sans-serif" font-size="32" fill="white">B</text>
+</svg>

--- a/public/logos/logo3.svg
+++ b/public/logos/logo3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#f97316"/>
+  <text x="60" y="38" text-anchor="middle" font-family="Inter, sans-serif" font-size="32" fill="white">C</text>
+</svg>

--- a/public/logos/logo4.svg
+++ b/public/logos/logo4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#6366f1"/>
+  <text x="60" y="38" text-anchor="middle" font-family="Inter, sans-serif" font-size="32" fill="white">D</text>
+</svg>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,17 +3,16 @@ import { Link } from '@builder.io/qwik-city';
 
 export const Hero = component$(() => {
   return (
-    <section class="bg-blue-600 text-white py-20">
+    <section class="bg-gradient-to-r from-blue-100 via-blue-200 to-blue-300 text-gray-900 py-24">
       <div class="max-w-6xl mx-auto px-4 text-center">
         <div class="animate-fade-in">
-          <h1 class="text-5xl md:text-6xl font-bold mb-6 leading-tight">
-            Turn AI <span class="fire-glow">FOMO</span> into <span class="text-yellow-300">ROI</span>
+          <h1 class="text-5xl md:text-6xl font-bold mb-8 leading-tight">
+            Transform AI Potential into {""}
+            <span class="text-yellow-500">Business Value</span>
           </h1>
           
-          <p class="text-xl md:text-2xl mb-8 text-blue-100 max-w-3xl mx-auto leading-relaxed">
-            Stop watching competitors leverage AI while you fall behind. 
-            Get live demos, expert guidance, and a custom MVP blueprint 
-            to transform your business with AI solutions.
+          <p class="text-xl md:text-2xl mb-10 text-blue-700 max-w-3xl mx-auto leading-relaxed">
+            Stop watching competitors leverage AI while you fall behind. Get live demos, expert guidance, and a custom MVP blueprint to transform your business with AI solutions.
           </p>
           
           <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
@@ -32,7 +31,9 @@ export const Hero = component$(() => {
             </Link>
           </div>
           
-          <div class="mt-12 text-blue-200">
+          <img src="/images/hero.svg" alt="Illustration representing AI solutions" class="mx-auto mt-10 w-full max-w-md" />
+
+          <div class="mt-12 text-blue-700">
             <p class="text-sm mb-2">⚡ Loads in &lt;1s on mobile</p>
             <p class="text-sm">🎯 Live AI demos • 📞 Discovery calls • 💡 MVP blueprints</p>
           </div>

--- a/src/global.css
+++ b/src/global.css
@@ -4,21 +4,25 @@
 
 /* Custom fire effect styles */
 .fire-glow {
-  text-shadow:
-    0 0 32px #ffd700,
-    0 0 64px #ff6600,
-    0 0 16px #ff3300,
-    0 2px 4px #000;
-  background: linear-gradient(90deg, rgba(255,200,50,0.25) 0%, rgba(255,150,0,0.18) 50%, rgba(255,0,0,0.22) 100%);
+  text-shadow: 0 0 2px rgba(255, 115, 0, 0.3);
+  background: linear-gradient(
+    90deg,
+    rgba(255, 200, 50, 0.1),
+    rgba(255, 80, 0, 0.05)
+  );
   -webkit-background-clip: text;
   background-clip: text;
-  filter: brightness(1.2) drop-shadow(0 0 40px #ffd70080) drop-shadow(0 0 80px #ff660080);
-  transition: text-shadow 0.3s, filter 0.3s;
+  filter: brightness(1.02);
+  transition: text-shadow 0.3s;
 }
 
 /* Ensure consistent box sizing without heavy global transitions */
 * {
   box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", sans-serif;
 }
 
 /* Custom scrollbar */
@@ -41,7 +45,8 @@
 
 /* Loading animation */
 @keyframes pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
   }
   50% {

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -14,6 +14,9 @@ export default component$(() => {
     <QwikCityProvider>
       <head>
         <meta charset="utf-8" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
         {!isDev && (
           <link
             rel="manifest"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,30 +7,22 @@ import { Footer } from '../components/Footer';
 
 export default component$(() => {
   return (
-    <div class="min-h-screen bg-blue-600">
+    <div class="min-h-screen bg-gradient-to-b from-blue-100 via-blue-200 to-blue-300 text-gray-900">
       <NavBar />
       <Hero />
       <ValueProps />
       
-      {/* Logos row placeholder */}
+      {/* Logos */}
       <section class="py-12 bg-white">
         <div class="max-w-6xl mx-auto px-4">
           <h3 class="text-center text-gray-600 text-sm font-medium mb-8 uppercase tracking-wide">
             Trusted by leading companies
           </h3>
-          <div class="flex justify-center items-center space-x-8 opacity-60">
-            <div class="bg-gray-200 h-12 w-32 rounded flex items-center justify-center">
-              <span class="text-gray-500 text-xs">Logo 1</span>
-            </div>
-            <div class="bg-gray-200 h-12 w-32 rounded flex items-center justify-center">
-              <span class="text-gray-500 text-xs">Logo 2</span>
-            </div>
-            <div class="bg-gray-200 h-12 w-32 rounded flex items-center justify-center">
-              <span class="text-gray-500 text-xs">Logo 3</span>
-            </div>
-            <div class="bg-gray-200 h-12 w-32 rounded flex items-center justify-center">
-              <span class="text-gray-500 text-xs">Logo 4</span>
-            </div>
+          <div class="flex justify-center items-center space-x-8 opacity-80">
+            <img src="/logos/logo1.svg" alt="Alpha Corp logo" class="h-12 w-32 object-contain" />
+            <img src="/logos/logo2.svg" alt="Beta Industries logo" class="h-12 w-32 object-contain" />
+            <img src="/logos/logo3.svg" alt="Creative Solutions logo" class="h-12 w-32 object-contain" />
+            <img src="/logos/logo4.svg" alt="Delta Systems logo" class="h-12 w-32 object-contain" />
           </div>
         </div>
       </section>
@@ -41,19 +33,21 @@ export default component$(() => {
 });
 
 export const head: DocumentHead = {
-  title: 'AISOLUTIONS - Turn AI FOMO into ROI',
+  title: "AISOLUTIONS - Transform AI Potential into Business Value",
   meta: [
     {
-      name: 'description',
-      content: 'Transform your business with AI solutions. Live demos, expert consultation, and MVP blueprints.',
+      name: "description",
+      content:
+        "Transform AI potential into business value with live demos, expert guidance, and MVP blueprints.",
     },
     {
-      property: 'og:title',
-      content: 'AISOLUTIONS - Turn AI FOMO into ROI',
+      property: "og:title",
+      content: "AISOLUTIONS - Transform AI Potential into Business Value",
     },
     {
-      property: 'og:description',
-      content: 'Transform your business with AI solutions. Live demos, expert consultation, and MVP blueprints.',
+      property: "og:description",
+      content:
+        "Transform AI potential into business value with live demos, expert guidance, and MVP blueprints.",
     },
   ],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,14 +1,17 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {
       colors: {
         primary: {
-          blue: '#0D6EFD',
-          red: '#DC3545',
-          green: '#198754'
-        }
+          blue: "#60a5fa",
+          red: "#f87171",
+          green: "#34d399",
+        },
+        light: {
+          background: "#f8fafc",
+        },
       },
       animation: {
         'fade-in': 'fadeIn 0.5s ease-in-out',


### PR DESCRIPTION
## Summary
- lighten hero background gradient and text shades
- apply same lighter gradient on index page
- keep Inter font globally and updated logos
- maintain subtler fire-glow effect and softer Tailwind colors

## Testing
- `npm run lint` *(fails: cannot find module '@typescript-eslint/eslint-plugin')*
- `npm run build` *(fails: qwik not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68646acbd09483329d3f8938f1ed10c1