### PR TITLE
Initialize Supabase schema on server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsI
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 ```
 
+The `SUPABASE_SERVICE_ROLE_KEY` is used during server start to automatically
+create the `waitlist` table if it doesn't exist. Ensure the built-in
+`execute_sql` RPC is enabled in your Supabase project so the initialization can
+run successfully.
+
 When deploying to Netlify, define these variables in your site's **Environment Variables** settings so the edge functions can connect to Supabase during runtime.
 
 ### Database Schema

--- a/src/entry.ssr.tsx
+++ b/src/entry.ssr.tsx
@@ -16,6 +16,10 @@ import {
 } from '@builder.io/qwik/server';
 import { manifest } from '@qwik-client-manifest';
 import Root from './root';
+import { initSupabaseSchema } from './lib/initSupabase';
+
+// Ensure the required database schema exists on startup
+void initSupabaseSchema();
 
 export default function (opts: RenderToStreamOptions) {
   return renderToStream(<Root />, {

--- a/src/lib/initSupabase.ts
+++ b/src/lib/initSupabase.ts
@@ -1,0 +1,57 @@
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * Initialize the Supabase schema on server startup.
+ * Connects using the service role key, checks if the `waitlist` table exists
+ * and creates it along with a basic RLS policy if missing.
+ * Requires the built-in `execute_sql` RPC to be enabled.
+ */
+export async function initSupabaseSchema() {
+  const url = process.env.SUPABASE_URL;
+  const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRole) {
+    console.warn('Supabase environment variables are not set');
+    return;
+  }
+
+  const supabase = createClient(url, serviceRole);
+
+  // Check if the waitlist table already exists
+  const checkSql =
+    "SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'waitlist'";
+  const { data: tableExists, error: checkError } = await supabase.rpc('execute_sql', {
+    sql: checkSql,
+  });
+  if (checkError) {
+    console.error('Error checking for waitlist table:', checkError);
+    return;
+  }
+  if (Array.isArray(tableExists) && tableExists.length > 0) {
+    // Table already present
+    return;
+  }
+
+  const createSql = `
+  CREATE TABLE IF NOT EXISTS waitlist (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    company_name VARCHAR(255),
+    company_size VARCHAR(50),
+    pain_point TEXT,
+    name TEXT,
+    ip_address TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+  );
+  ALTER TABLE waitlist ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY waitlist_insert ON waitlist FOR INSERT WITH CHECK (true);
+  CREATE POLICY waitlist_select ON waitlist FOR SELECT USING (true);
+  `;
+
+  const { error: createError } = await supabase.rpc('execute_sql', { sql: createSql });
+  if (createError) {
+    console.error('Error creating waitlist table:', createError);
+  } else {
+    console.log('Waitlist table created');
+  }
+}


### PR DESCRIPTION
## Summary
- add an `initSupabaseSchema` helper that uses the service role key
- call the initializer during SSR startup
- document the new environment variable and how to enable `execute_sql`

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6864e9bcf01083329ddb33a703c16073