### PR TITLE
Update CORS origin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 
 When deploying to Netlify, define these variables in your site's **Environment Variables** settings so the edge functions can connect to Supabase during runtime.
 
+Set `ALLOWED_ORIGIN` to your site's domain to control which origin may call the waitlist API. Example:
+
+```env
+ALLOWED_ORIGIN=https://example.com
+```
+
 ### Database Schema
 
 ```sql

--- a/src/routes/api/join-waitlist/index.ts
+++ b/src/routes/api/join-waitlist/index.ts
@@ -10,8 +10,9 @@ interface WaitlistData {
 }
 
 export const onPost: RequestHandler = async ({ json, request, headers }) => {
-  // Allow cross-origin requests
-  headers.set('Access-Control-Allow-Origin', '*');
+  // Allow cross-origin requests from the configured origin
+  const allowedOrigin = process.env.ALLOWED_ORIGIN || '*';
+  headers.set('Access-Control-Allow-Origin', allowedOrigin);
   try {
     const data: WaitlistData = await request.json();
     const ip =
@@ -83,7 +84,8 @@ export const onPost: RequestHandler = async ({ json, request, headers }) => {
 
 // Handle preflight requests for CORS
 export const onOptions: RequestHandler = async ({ headers }) => {
-  headers.set('Access-Control-Allow-Origin', '*');
+  const allowedOrigin = process.env.ALLOWED_ORIGIN || '*';
+  headers.set('Access-Control-Allow-Origin', allowedOrigin);
   headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
   headers.set('Access-Control-Allow-Headers', 'Content-Type');
 };


### PR DESCRIPTION
## Summary
- allow configuring `Access-Control-Allow-Origin` in waitlist API using an environment variable
- document `ALLOWED_ORIGIN` in README

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6864e9d4e0a4833289dd9f3d56212381