### PR TITLE
Implement waitlist state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ src/
 │   ├── index.tsx          # Landing page (blue theme)
 │   ├── demo/index.tsx     # Demo showcase (red theme)
 │   ├── join/index.tsx     # Wait-list page (green theme)
-│   └── api/join-waitlist/ # API endpoint for form submissions
+│   └── api/waitlist/      # API endpoint for form submissions
 ├── components/
 │   ├── NavBar.tsx         # Navigation component
 │   ├── Hero.tsx           # Hero section with CTA
@@ -26,7 +26,8 @@ src/
 │   ├── DemoShowcase.tsx   # Demo tabs container
 │   ├── Chatbot.tsx        # Interactive AI chatbot
 │   ├── CTAJoinWaitlist.tsx# Call-to-action banner
-│   ├── WaitlistForm.tsx   # Email capture form
+│   ├── WaitlistMachine.tsx# Waitlist state machine component
+│   ├── WaitlistForm.tsx   # Legacy form component
 │   ├── Testimonials.tsx   # Social proof section
 │   ├── FAQ.tsx            # Frequently asked questions
 │   └── Footer.tsx         # Site footer

--- a/src/components/WaitlistMachine.tsx
+++ b/src/components/WaitlistMachine.tsx
@@ -1,0 +1,72 @@
+import { component$, useSignal } from '@builder.io/qwik';
+
+export type WaitlistState = 'idle' | 'submitting' | 'success' | 'error';
+
+export const WaitlistMachine = component$(() => {
+  const email = useSignal('');
+  const state = useSignal<WaitlistState>('idle');
+  const timerVisible = useSignal(false);
+  const errorMsg = useSignal('');
+
+  const submit = async () => {
+    if (state.value === 'submitting') return;
+    state.value = 'submitting';
+    timerVisible.value = true;
+
+    try {
+      const res = await fetch('/api/waitlist', {
+        method: 'POST',
+        body: JSON.stringify({ email: email.value }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      const data = await res.json();
+
+      if (!res.ok || data.error) {
+        throw new Error(data.error || 'Unknown error');
+      }
+
+      state.value = 'success';
+    } catch (err: any) {
+      console.error('Insert failed:', err);
+      errorMsg.value = err.message;
+      state.value = 'error';
+    } finally {
+      timerVisible.value = false;
+    }
+  };
+
+  return (
+    <div>
+      {state.value === 'success' ? (
+        <p class="text-green-600">✅ You're on the waitlist!</p>
+      ) : (
+        <>
+          <input
+            type="email"
+            bind:value={email}
+            placeholder="Your email"
+            class="border rounded p-2 mr-2"
+          />
+          <button
+            onClick$={submit}
+            disabled={state.value === 'submitting'}
+            class="bg-blue-500 text-white px-4 py-2 rounded"
+          >
+            Join Waitlist
+          </button>
+
+          {timerVisible.value && (
+            <p class="text-sm text-gray-500 mt-2">⏳ Saving your request...</p>
+          )}
+
+          {state.value === 'error' && (
+            <p class="text-red-600 mt-2">❌ {errorMsg.value}</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+});

--- a/src/routes/api/waitlist/index.ts
+++ b/src/routes/api/waitlist/index.ts
@@ -1,0 +1,23 @@
+import { type RequestHandler } from '@builder.io/qwik-city';
+import { createClient } from '@supabase/supabase-js';
+
+export const onPost: RequestHandler = async ({ request, json }) => {
+  const { email } = await request.json();
+
+  const url = process.env.SUPABASE_URL;
+  const anon = process.env.SUPABASE_ANON_KEY;
+
+  if (!url || !anon) {
+    return json(500, { error: 'Supabase env vars missing' });
+  }
+
+  const supabase = createClient(url, anon);
+
+  const { error } = await supabase.from('waitlist').insert({ email });
+
+  if (error) {
+    return json(500, { error: error.message });
+  }
+
+  return json(200, { success: true });
+};

--- a/src/routes/join/index.tsx
+++ b/src/routes/join/index.tsx
@@ -1,7 +1,7 @@
 import { component$ } from '@builder.io/qwik';
 import type { DocumentHead } from '@builder.io/qwik-city';
 import { NavBar } from '../../components/NavBar';
-import { WaitlistForm } from '../../components/WaitlistForm';
+import { WaitlistMachine } from '../../components/WaitlistMachine';
 import { Testimonials } from '../../components/Testimonials';
 import { FAQ } from '../../components/FAQ';
 import { Footer } from '../../components/Footer';
@@ -27,7 +27,7 @@ export default component$(() => {
 
       {/* Main Content */}
       <div class="bg-white">
-        <WaitlistForm />
+        <WaitlistMachine />
         <Testimonials />
         <FAQ />
       </div>


### PR DESCRIPTION
## Summary
- add WaitlistMachine component with explicit states and loader
- add `/api/waitlist` endpoint for Supabase inserts
- update waitlist page to use new machine component
- document new component and endpoint in README

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6864ed1c4f548332931d1af38372a962