### PR TITLE
Fix waitlist form API endpoint

### DIFF
--- a/src/components/WaitlistMachine.tsx
+++ b/src/components/WaitlistMachine.tsx
@@ -46,7 +46,7 @@ export const WaitlistMachine = component$(() => {
     errorMsg.value = '';
 
     try {
-      const res = await fetch('/api/waitlist', {
+      const res = await fetch('/api/join-waitlist', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData),


### PR DESCRIPTION
## Summary
- fix waitlist machine to call the full waitlist API

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6864f70a157083329f56ecf0f1a0fcfd