### PR TITLE
Update env instructions and fallback env names

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,14 @@ cp .env.example .env.local
 ```
 
 ```env
+# Required server credentials
 SUPABASE_URL=https://tpyfvcbudxtjqowwkmhu.supabase.co
 SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRweWZ2Y2J1ZHh0anFvd3drbWh1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTE0NDAzNTYsImV4cCI6MjA2NzAxNjM1Nn0.CYt-h9Oywm8b_GxGQeJKSGOnAIzBIHikX3g6Cg
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+
+# Optional PUBLIC_ variants are also supported
+PUBLIC_SUPABASE_URL=$SUPABASE_URL
+PUBLIC_SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
 ```
 
 The `SUPABASE_SERVICE_ROLE_KEY` is used during server start to automatically

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,14 +1,15 @@
 import { createClient } from '@supabase/supabase-js';
 
 export function createSupabaseServerClient() {
-  const url = process.env.SUPABASE_URL;
+  const url = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  const anonKey = process.env.SUPABASE_ANON_KEY;
+  const anonKey =
+    process.env.SUPABASE_ANON_KEY || process.env.PUBLIC_SUPABASE_ANON_KEY;
   const key = serviceKey || anonKey;
 
   if (!url || !key) {
     throw new Error(
-      'Missing Supabase environment variables (SUPABASE_URL and API key)'
+      'Missing Supabase environment variables (SUPABASE_URL/PUBLIC_SUPABASE_URL and API key)'
     );
   }
 


### PR DESCRIPTION
## Summary
- allow `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY` in `createSupabaseServerClient`
- document optional PUBLIC_ variables in README for clarity

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68651bc412e48332b181a621bae1cff2