### PR TITLE
Add email sending for contact form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ ALLOWED_ORIGIN=https://example.com
 # Variables available in the browser
 PUBLIC_SUPABASE_URL=$SUPABASE_URL
 PUBLIC_SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_username
+SMTP_PASS=your_password
+CONTACT_RECIPIENT=timnewlink@gmail.com

--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ Set `ALLOWED_ORIGIN` to your site's domain to control which origin may call the 
 ALLOWED_ORIGIN=https://example.com
 ```
 
+### SMTP Configuration
+
+Configure SMTP credentials so the contact form can send email notifications:
+
+```env
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_username
+SMTP_PASS=your_password
+# Optional override for the recipient address
+CONTACT_RECIPIENT=timnewlink@gmail.com
+```
+
 ### Database Schema
 
 ```sql
@@ -306,7 +319,7 @@ When debugging deployment issues:
 
 ## 💡 Improvement Ideas
 
-- Add a dedicated contact page with an embedded form.
+- ✅ Add a dedicated contact page with an embedded form.
 - Publish case studies or blog posts to showcase success stories.
 - Improve SEO by adding meta tags and structured data.
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prettier": "3.3.3",
     "tailwindcss": "^3.4.0",
     "three": "^0.175.0",
+    "nodemailer": "^6.9.3",
     "typescript": "5.4.5",
     "vite": "^5.2.10",
     "vite-tsconfig-paths": "^4.2.1"

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,130 @@
+import { component$, useSignal, useStore, $ } from '@builder.io/qwik';
+
+interface ContactData {
+  name: string;
+  email: string;
+  message: string;
+}
+
+export const ContactForm = component$(() => {
+  const formData = useStore<ContactData>({
+    name: '',
+    email: '',
+    message: '',
+  });
+
+  const sent = useSignal(false);
+  const error = useSignal('');
+
+  const submit = $(async () => {
+    if (!formData.name || !formData.email || !formData.message) {
+      error.value = 'Please fill in all fields.';
+      return;
+    }
+    if (!formData.email.includes('@')) {
+      error.value = 'Please enter a valid email address.';
+      return;
+    }
+
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to send message');
+      }
+      sent.value = true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      error.value = message;
+    }
+  });
+
+  if (sent.value) {
+    return (
+      <div class="bg-green-50 border border-green-200 rounded-2xl p-8 text-center animate-scale-in">
+        <div class="text-4xl mb-4">🎉</div>
+        <h2 class="text-2xl font-bold text-green-800 mb-2">Message sent!</h2>
+        <p class="text-green-700">We'll get back to you soon.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form preventdefault:submit onSubmit$={submit} class="space-y-6">
+      <div
+        class="bg-yellow-50 border-l-4 border-yellow-400 text-yellow-700 p-4 rounded-lg mb-6"
+        role="alert"
+      >
+        <span class="font-semibold">⚠️ Form not functional yet!</span>
+        Please reach out via
+        <a href="https://wa.me/4915164438355" class="underline font-medium">WhatsApp</a>
+        or
+        <a href="mailto:tim.woell@gmail.com" class="underline font-medium">email</a>
+        in the meantime.
+      </div>
+      {error.value && (
+        <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg" role="alert" aria-live="assertive">
+          {error.value}
+        </div>
+      )}
+      <div>
+        <label for="name" class="block text-sm font-medium text-gray-700 mb-2">
+          Full Name *
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          value={formData.name}
+          onInput$={(e) => (formData.name = (e.target as HTMLInputElement).value)}
+          class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          placeholder="John Smith"
+          autoComplete="name"
+          required
+        />
+      </div>
+      <div>
+        <label for="email" class="block text-sm font-medium text-gray-700 mb-2">
+          Email *
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          value={formData.email}
+          onInput$={(e) => (formData.email = (e.target as HTMLInputElement).value)}
+          class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          placeholder="john@example.com"
+          autoComplete="email"
+          required
+        />
+      </div>
+      <div>
+        <label for="message" class="block text-sm font-medium text-gray-700 mb-2">
+          Message *
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          rows={4}
+          value={formData.message}
+          onInput$={(e) => (formData.message = (e.target as HTMLTextAreaElement).value)}
+          class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          placeholder="How can we help you?"
+          required
+        ></textarea>
+      </div>
+      <button
+        type="submit"
+        class="w-full bg-blue-600 text-white py-4 px-6 rounded-lg font-semibold text-lg hover:bg-blue-700 transition-all duration-300 hover:scale-105"
+      >
+        Send Message
+      </button>
+    </form>
+  );
+});
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -75,12 +75,12 @@ export const Footer = component$(() => {
                 </Link>
               </li>
               <li>
-                <a
-                  href="#"
+                <Link
+                  href="/contact/"
                   class="text-gray-400 hover:text-white transition-colors"
                 >
-                  About Us
-                </a>
+                  Contact
+                </Link>
               </li>
             </ul>
           </div>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -53,6 +53,16 @@ export const NavBar = component$(() => {
             >
               Wait-list
             </Link>
+            <Link
+              href="/contact/"
+              class={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                isActive('/contact/')
+                  ? 'text-blue-600 bg-blue-50'
+                  : 'text-gray-700 hover:text-blue-600 hover:bg-gray-50'
+              }`}
+            >
+              Contact
+            </Link>
           </div>
 
           {/* Mobile menu button */}
@@ -109,6 +119,16 @@ export const NavBar = component$(() => {
               }`}
             >
               Wait-list
+            </Link>
+            <Link
+              href="/contact/"
+              class={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                isActive('/contact/')
+                  ? 'text-blue-600 bg-blue-50'
+                  : 'text-gray-700 hover:text-blue-600 hover:bg-gray-50'
+              }`}
+            >
+              Contact
             </Link>
           </div>
         </div>

--- a/src/components/WaitlistMachine.tsx
+++ b/src/components/WaitlistMachine.tsx
@@ -144,7 +144,7 @@ export const WaitlistMachine = component$(() => {
             class="bg-yellow-50 border-l-4 border-yellow-400 text-yellow-700 p-4 rounded-lg mb-6"
             role="alert"
           >
-            <span class="font-semibold">⚠️ Not functional yet:</span>
+            <span class="font-semibold">⚠️ Wait-list not functional yet! </span>
             Please reach out via
             <a href="https://wa.me/4915164438355" class="underline font-medium">
               WhatsApp
@@ -153,7 +153,7 @@ export const WaitlistMachine = component$(() => {
             <a href="mailto:tim.woell@gmail.com" class="underline font-medium">
               email
             </a>
-            to join the wait-list.
+            so we can notify you once it's live.
           </div>
 
           <form preventdefault:submit onSubmit$={submit} class="space-y-6">

--- a/src/routes/api/contact/index.ts
+++ b/src/routes/api/contact/index.ts
@@ -1,0 +1,54 @@
+import type { RequestHandler } from '@builder.io/qwik-city';
+import nodemailer from 'nodemailer';
+
+export const onPost: RequestHandler = async ({ request, json, headers }) => {
+  const allowedOrigin = process.env.ALLOWED_ORIGIN || '*';
+  headers.set('Access-Control-Allow-Origin', allowedOrigin);
+  headers.set('Access-Control-Allow-Headers', 'Content-Type');
+  headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+
+  try {
+    const { name, email, message } = await request.json();
+    if (!name || !email || !message) {
+      json(400, { error: 'Missing required fields' });
+      return;
+    }
+
+    const smtpHost = process.env.SMTP_HOST;
+    const smtpPort = Number(process.env.SMTP_PORT || '587');
+    const smtpUser = process.env.SMTP_USER;
+    const smtpPass = process.env.SMTP_PASS;
+    const recipient = process.env.CONTACT_RECIPIENT || 'timnewlink@gmail.com';
+
+    if (!smtpHost || !smtpUser || !smtpPass) {
+      json(500, { error: 'SMTP configuration missing' });
+      return;
+    }
+
+    const transporter = nodemailer.createTransport({
+      host: smtpHost,
+      port: smtpPort,
+      secure: smtpPort === 465,
+      auth: { user: smtpUser, pass: smtpPass },
+    });
+
+    await transporter.sendMail({
+      from: smtpUser,
+      to: recipient,
+      subject: `New contact from ${name}`,
+      text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
+    });
+
+    json(200, { success: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    json(500, { error: message });
+  }
+};
+
+export const onOptions: RequestHandler = async ({ headers }) => {
+  const allowedOrigin = process.env.ALLOWED_ORIGIN || '*';
+  headers.set('Access-Control-Allow-Origin', allowedOrigin);
+  headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Content-Type');
+};

--- a/src/routes/contact/index.tsx
+++ b/src/routes/contact/index.tsx
@@ -1,0 +1,46 @@
+import { component$ } from '@builder.io/qwik';
+import type { DocumentHead } from '@builder.io/qwik-city';
+import { NavBar } from '../../components/NavBar';
+import { Footer } from '../../components/Footer';
+import { ContactForm } from '../../components/ContactForm';
+
+export default component$(() => {
+  return (
+    <div class="min-h-screen bg-blue-600">
+      <NavBar />
+      <section class="bg-blue-600 text-white py-16">
+        <div class="max-w-4xl mx-auto px-4 text-center">
+          <h1 class="text-4xl md:text-5xl font-bold mb-6">Contact Us</h1>
+          <p class="text-xl text-blue-100 max-w-2xl mx-auto">
+            We'd love to hear from you. Send us a message and we'll respond as soon as possible.
+          </p>
+        </div>
+      </section>
+      <div class="bg-white py-16">
+        <div class="max-w-2xl mx-auto px-4">
+          <ContactForm />
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+});
+
+export const head: DocumentHead = {
+  title: 'Contact Us - AISOLUTIONS',
+  meta: [
+    {
+      name: 'description',
+      content: 'Get in touch with the AISOLUTIONS team for questions or support.',
+    },
+    {
+      property: 'og:title',
+      content: 'Contact Us - AISOLUTIONS',
+    },
+    {
+      property: 'og:description',
+      content: 'Reach out to the AISOLUTIONS team.',
+    },
+  ],
+};
+


### PR DESCRIPTION
## Summary
- send contact form submissions to an SMTP address
- post form data to new API endpoint
- document SMTP variables and example values
- include nodemailer in project dependencies
- add waitlist and contact warnings while forms are offline

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_686693a73cdc8332a0483615d81a03b0