### PR TITLE
Add Stripe donation page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ ALLOWED_ORIGIN=https://example.com
 # Variables available in the browser
 PUBLIC_SUPABASE_URL=$SUPABASE_URL
 PUBLIC_SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
+
+# Stripe keys for the donation page (replace with your own)
+STRIPE_PUBLIC_KEY=pk_test_your_key
+STRIPE_SECRET_KEY=sk_test_your_key
+STRIPE_WEBHOOK_SECRET=whsec_your_key
+NEXT_PUBLIC_APP_URL=http://localhost:5173

--- a/STRIPE_DONATION_SETUP.md
+++ b/STRIPE_DONATION_SETUP.md
@@ -11,13 +11,16 @@ This document outlines the steps needed to integrate Stripe donations into the W
 ## Setup Steps
 
 ### 1. Install Dependencies
+
 ```bash
 npm install @stripe/stripe-js
 npm install --save-dev @types/stripe__stripe-js
 ```
 
 ### 2. Environment Variables
+
 Add to `.env`:
+
 ```
 STRIPE_PUBLIC_KEY=pk_test_your_test_public_key
 STRIPE_SECRET_KEY=sk_test_your_test_secret_key
@@ -26,28 +29,42 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 ```
 
 ### 3. Create Donation Component
+
 Create: `src/components/donation/DonationCard.tsx`
+
 - Amount selection buttons
 - Custom amount input
 - Donation button
 - Loading states
 
-### 4. Create API Route
+### 4. Create Donation Page
+
+Create: `src/routes/donation/index.tsx`
+
+- Embed the `DonationCard` component
+- Add page header and description
+
+### 5. Create API Route
+
 Create: `src/routes/api/stripe/checkout/route.ts`
+
 - Handle checkout session creation
 - Process payment intents
 - Handle webhook events
 
-### 5. Create Success/Cancel Pages
+### 6. Create Success/Cancel Pages
+
 - `src/routes/donation/success.tsx`
 - `src/routes/donation/cancel.tsx`
 
-### 6. Add to Navigation
+### 7. Add to Navigation
+
 Add donation link to main navigation
 
 ## Implementation Details
 
 ### Donation Flow
+
 1. User selects amount/clicks donate
 2. Create Stripe Checkout session
 3. Redirect to Stripe Checkout
@@ -55,32 +72,38 @@ Add donation link to main navigation
 5. Redirect back to success/cancel page
 
 ### Environment Configuration
+
 - Test mode: Uses test keys
 - Production: Uses live keys
 - Webhook setup required for live mode
 
 ## Testing
+
 1. Test with Stripe test cards:
    - Success: 4242 4242 4242 4242
    - Decline: 4000 0000 0000 0002
 
 ## Deployment
+
 1. Set up environment variables in production
 2. Configure webhook in Stripe Dashboard
 3. Test end-to-end flow
 
 ## Security Considerations
+
 - Never expose secret keys in client-side code
 - Validate all webhook events
 - Use HTTPS in production
 - Implement rate limiting
 
 ## Resources
+
 - [Stripe Docs](https://stripe.com/docs)
 - [Stripe Checkout](https://stripe.com/docs/payments/checkout)
 - [Stripe Webhooks](https://stripe.com/docs/webhooks)
 
 ## Notes
+
 - Test thoroughly in development before going live
 - Monitor Stripe Dashboard for failed payments
 - Consider adding analytics for donation tracking

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -76,6 +76,14 @@ export const Footer = component$(() => {
               </li>
               <li>
                 <Link
+                  href="/donation/"
+                  class="text-gray-400 hover:text-white transition-colors"
+                >
+                  Donate
+                </Link>
+              </li>
+              <li>
+                <Link
                   href="/contact/"
                   class="text-gray-400 hover:text-white transition-colors"
                 >

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -54,6 +54,16 @@ export const NavBar = component$(() => {
               Wait-list
             </Link>
             <Link
+              href="/donation/"
+              class={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                isActive('/donation/')
+                  ? 'text-purple-600 bg-purple-50'
+                  : 'text-gray-700 hover:text-purple-600 hover:bg-gray-50'
+              }`}
+            >
+              Donate
+            </Link>
+            <Link
               href="/contact/"
               class={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
                 isActive('/contact/')
@@ -119,6 +129,16 @@ export const NavBar = component$(() => {
               }`}
             >
               Wait-list
+            </Link>
+            <Link
+              href="/donation/"
+              class={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                isActive('/donation/')
+                  ? 'text-purple-600 bg-purple-50'
+                  : 'text-gray-700 hover:text-purple-600 hover:bg-gray-50'
+              }`}
+            >
+              Donate
             </Link>
             <Link
               href="/contact/"

--- a/src/components/donation/DonationCard.tsx
+++ b/src/components/donation/DonationCard.tsx
@@ -1,0 +1,111 @@
+import { component$, useStore, $ } from '@builder.io/qwik';
+
+interface DonationState {
+  amount: string;
+  custom: string;
+  loading: boolean;
+  error: string;
+}
+
+export const DonationCard = component$(() => {
+  const state = useStore<DonationState>({
+    amount: '5',
+    custom: '',
+    loading: false,
+    error: '',
+  });
+
+  const donate = $(async () => {
+    if (state.loading) return;
+
+    const value = state.custom
+      ? parseFloat(state.custom)
+      : parseFloat(state.amount);
+    if (isNaN(value) || value <= 0) {
+      state.error = 'Please enter a valid amount.';
+      return;
+    }
+
+    state.loading = true;
+    state.error = '';
+
+    try {
+      const res = await fetch('/api/stripe/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: Math.round(value * 100) }),
+      });
+
+      const data = await res.json();
+      if (!res.ok || !data.url) {
+        throw new Error(data.error || 'Checkout session failed');
+      }
+
+      if (typeof window !== 'undefined') {
+        window.location.href = data.url as string;
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      state.error = message;
+    } finally {
+      state.loading = false;
+    }
+  });
+
+  return (
+    <div class="bg-white rounded-2xl shadow-xl p-8">
+      <h2 class="text-2xl font-bold text-gray-900 mb-6 text-center">
+        Make a Donation
+      </h2>
+      {state.error && (
+        <div
+          class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4"
+          role="alert"
+        >
+          {state.error}
+        </div>
+      )}
+      <div class="flex justify-center space-x-2 mb-4">
+        {['5', '10', '25'].map((amt) => (
+          <button
+            key={amt}
+            onClick$={() => {
+              state.amount = amt;
+              state.custom = '';
+            }}
+            class={`px-4 py-2 rounded-lg border ${state.amount === amt && !state.custom ? 'bg-purple-600 text-white' : 'bg-white text-gray-700'}`}
+          >
+            ${amt}
+          </button>
+        ))}
+      </div>
+      <div class="mb-4">
+        <label
+          class="block text-sm font-medium text-gray-700 mb-1"
+          for="custom"
+        >
+          Custom amount
+        </label>
+        <input
+          id="custom"
+          type="number"
+          min="1"
+          value={state.custom}
+          onInput$={(e) => {
+            state.custom = (e.target as HTMLInputElement).value;
+            state.amount = '';
+          }}
+          class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+          placeholder="USD"
+        />
+      </div>
+      <button
+        disabled={state.loading}
+        onClick$={donate}
+        class="w-full bg-purple-600 text-white py-3 px-6 rounded-lg font-semibold hover:bg-purple-700 disabled:opacity-50"
+      >
+        {state.loading ? 'Processing...' : 'Donate'}
+      </button>
+    </div>
+  );
+});

--- a/src/routes/api/stripe/checkout/route.ts
+++ b/src/routes/api/stripe/checkout/route.ts
@@ -1,0 +1,41 @@
+import { type RequestHandler } from '@builder.io/qwik-city';
+import Stripe from 'stripe';
+
+export const onPost: RequestHandler = async ({ request, json }) => {
+  try {
+    const { amount } = await request.json();
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+      apiVersion: '2024-04-10',
+    });
+
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            unit_amount: amount,
+            product_data: { name: 'Donation' },
+          },
+          quantity: 1,
+        },
+      ],
+      success_url: `${process.env.NEXT_PUBLIC_APP_URL}/donation/success`,
+      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/donation/cancel`,
+    });
+
+    json(200, { url: session.url });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('Stripe error:', message);
+    json(500, { error: message });
+  }
+};
+
+export const onOptions: RequestHandler = async ({ headers }) => {
+  const allowedOrigin = process.env.ALLOWED_ORIGIN || '*';
+  headers.set('Access-Control-Allow-Origin', allowedOrigin);
+  headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Content-Type');
+};

--- a/src/routes/donation/cancel.tsx
+++ b/src/routes/donation/cancel.tsx
@@ -1,0 +1,23 @@
+import { component$ } from '@builder.io/qwik';
+import type { DocumentHead } from '@builder.io/qwik-city';
+import { NavBar } from '../../components/NavBar';
+import { Footer } from '../../components/Footer';
+
+export default component$(() => {
+  return (
+    <div class="min-h-screen bg-purple-600">
+      <NavBar />
+      <section class="bg-purple-600 text-white py-32">
+        <div class="max-w-xl mx-auto px-4 text-center">
+          <h1 class="text-4xl font-bold mb-4">Donation Canceled</h1>
+          <p class="text-purple-100 text-lg">Your donation was canceled.</p>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+});
+
+export const head: DocumentHead = {
+  title: 'Donation Canceled - AISOLUTIONS',
+};

--- a/src/routes/donation/index.tsx
+++ b/src/routes/donation/index.tsx
@@ -1,0 +1,45 @@
+import { component$ } from '@builder.io/qwik';
+import type { DocumentHead } from '@builder.io/qwik-city';
+import { NavBar } from '../../components/NavBar';
+import { DonationCard } from '../../components/donation/DonationCard';
+import { Footer } from '../../components/Footer';
+
+export default component$(() => {
+  return (
+    <div class="min-h-screen bg-purple-600">
+      <NavBar />
+      <section class="bg-purple-600 text-white py-16">
+        <div class="max-w-4xl mx-auto px-4 text-center">
+          <h1 class="text-4xl md:text-5xl font-bold mb-6">Support Our Work</h1>
+          <p class="text-xl text-purple-100 max-w-2xl mx-auto">
+            Your donations help us continue building open-source AI solutions.
+          </p>
+        </div>
+      </section>
+      <div class="bg-white py-16">
+        <div class="max-w-md mx-auto px-4">
+          <DonationCard />
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+});
+
+export const head: DocumentHead = {
+  title: 'Donate - AISOLUTIONS',
+  meta: [
+    {
+      name: 'description',
+      content: 'Contribute to support the development of our AI solutions.',
+    },
+    {
+      property: 'og:title',
+      content: 'Donate - AISOLUTIONS',
+    },
+    {
+      property: 'og:description',
+      content: 'Contribute to support the development of our AI solutions.',
+    },
+  ],
+};

--- a/src/routes/donation/success.tsx
+++ b/src/routes/donation/success.tsx
@@ -1,0 +1,25 @@
+import { component$ } from '@builder.io/qwik';
+import type { DocumentHead } from '@builder.io/qwik-city';
+import { NavBar } from '../../components/NavBar';
+import { Footer } from '../../components/Footer';
+
+export default component$(() => {
+  return (
+    <div class="min-h-screen bg-purple-600">
+      <NavBar />
+      <section class="bg-purple-600 text-white py-32">
+        <div class="max-w-xl mx-auto px-4 text-center">
+          <h1 class="text-4xl font-bold mb-4">Thank You!</h1>
+          <p class="text-purple-100 text-lg">
+            Your donation was successful. We appreciate your support.
+          </p>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+});
+
+export const head: DocumentHead = {
+  title: 'Donation Successful - AISOLUTIONS',
+};


### PR DESCRIPTION
## Summary
- add placeholder Stripe keys to `.env.example`
- document donation page creation steps
- add donation link in navbar and footer
- implement `<DonationCard>` component
- create donation API route and pages

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_687387a7d27483328c8e0418479bbc0b