### PR TITLE
Add placeholder donate page and nav link

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -63,6 +63,12 @@ export const NavBar = component$(() => {
             >
               Contact
             </Link>
+            <Link
+              href="/donate/"
+              class="px-3 py-2 rounded-md text-sm font-medium text-white bg-gradient-to-r from-pink-500 to-rose-500 hover:from-pink-600 hover:to-rose-600 transition-colors"
+            >
+              Donate
+            </Link>
           </div>
 
           {/* Mobile menu button */}

--- a/src/routes/donate/index.tsx
+++ b/src/routes/donate/index.tsx
@@ -1,5 +1,5 @@
 import { component$ } from '@builder.io/qwik';
-import { DonationForm } from '~/components/DonationForm';
+// Donation functionality coming soon
 import { NavBar } from '~/components/NavBar';
 import { Footer } from '~/components/Footer';
 
@@ -19,27 +19,21 @@ export default component$(() => {
             </p>
           </div>
           
-          <div class="bg-white rounded-2xl shadow-xl overflow-hidden max-w-3xl mx-auto">
-            <div class="p-6 sm:p-8">
-              <DonationForm />
-            </div>
-            
-            <div class="bg-blue-50 border-t border-blue-100 p-6">
-              <div class="flex items-start">
-                <div class="flex-shrink-0">
-                  <svg class="h-6 w-6 text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                  </svg>
-                </div>
-                <div class="ml-3">
-                  <h3 class="text-sm font-medium text-blue-800">Secure & Encrypted</h3>
-                  <div class="mt-1 text-sm text-blue-700">
-                    <p>
-                      Your payment is processed securely via Stripe. We never store your payment details on our servers.
-                    </p>
-                  </div>
-                </div>
-              </div>
+          <div class="bg-white rounded-2xl shadow-xl overflow-hidden max-w-3xl mx-auto p-6 sm:p-8">
+            <div
+              class="bg-yellow-50 border-l-4 border-yellow-400 text-yellow-700 p-4 rounded-lg mb-6"
+              role="alert"
+            >
+              <span class="font-semibold">⚠️ Not functional yet:</span>
+              Please reach out via
+              <a href="https://wa.me/4915164438355" class="underline font-medium">
+                WhatsApp
+              </a>
+              or
+              <a href="mailto:tim.woell@gmail.com" class="underline font-medium">
+                email
+              </a>
+              to join the wait-list.
             </div>
           </div>
           


### PR DESCRIPTION
## Summary
- add Donate link to desktop navigation
- create placeholder donate page with 'not functional yet' warning

## Testing
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68739d263e1c8332822b320c034983b7